### PR TITLE
V1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## [1.1] - 2017-09-05
 ## Changed
-- [tclNote.tcl]:
+- [tclNote.tcl] line 107: `set htmlTail "\n</p><footer>[clock format [clock seconds] -gmt 1]</footer></body></html>";`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## [1.1] - 2017-09-05
+## Changed
+- [tclNote.tcl]:

--- a/tclNote.tcl
+++ b/tclNote.tcl
@@ -104,7 +104,7 @@ namespace eval ::tclNote {
 				#CSS
 				set cssFont [expr {[llength [.fontLbl.font get]]?"<style type=\"text/css\">\n\#pMain\{font-family:\"[.fontLbl.font get]\",monospace\;\}\n</style>":{}}];
 				set htmlHead "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"generator\" content=\"tclNote\"><title>tclNote_html</title>$cssFont</head><body><p id=\"pMain\">\n";
-				set htmlTail "\n</p><footer>[clock format [clock seconds]]</footer></body></html>";
+				set htmlTail "\n</p><footer>[clock format [clock seconds] -gmt 1]</footer></body></html>";
 				::tclNote::fWrite $htmlPath "$htmlHead[regsub -all {\n} [.txtA get 1.0 end] {<br>}]$htmlTail";
 			};
 			#[Event]: inserting Unicode characters


### PR DESCRIPTION
## [1.1] - 2017-09-05
## Changed
- set time format of html output as GMT;   
  [tclNote.tcl] line 107: `set htmlTail "\n</p><footer>[clock format [clock seconds] -gmt 1]</footer></body></html>";`